### PR TITLE
Disable not needed gcc components

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,7 +23,9 @@ GCC_CONFIGURE_OPTS = \
   --enable-targets=all \
   --disable-libquadmath \
   --disable-libssp \
-  --disable-libgomp
+  --disable-libgomp \
+  --disable-multilib \
+  --disable-libstdcxx
 
 DESTDIR=$(CURDIR)/debian/ghdl
 


### PR DESCRIPTION
multilib requires to have installed additional gcc stuff
c++ stdlib is also not needed